### PR TITLE
Fixbug when raw_img=[None].

### DIFF
--- a/DFP/doom_simulator.py
+++ b/DFP/doom_simulator.py
@@ -119,7 +119,7 @@ class DoomSimulator:
                 
             if self.resize:
                 if self.num_channels == 1:
-                    if raw_img is None:
+                    if raw_img is None or raw_img[0] is None:
                         img = None
                     else:
                         img = cv2.resize(raw_img[0], (self.resolution[0], self.resolution[1]))[None,:,:]

--- a/DFP/doom_simulator.py
+++ b/DFP/doom_simulator.py
@@ -119,7 +119,7 @@ class DoomSimulator:
                 
             if self.resize:
                 if self.num_channels == 1:
-                    if raw_img is None or raw_img[0] is None:
+                    if raw_img is None or (isinstance(raw_img, list) and raw_img[0] is None):
                         img = None
                     else:
                         img = cv2.resize(raw_img[0], (self.resolution[0], self.resolution[1]))[None,:,:]


### PR DESCRIPTION
In my case, I run this code with python2.7 and the error occured when `raw_img=[None]`. This will lead to run `cv2.resize(None, (self.resolution[0], self.resolution[1]))[None,:,:]` and resize `None` value, which makes a mistake. When fixing up this line, the code can run with python2.7 normally.